### PR TITLE
Add IAM and Lambda tagging permissions

### DIFF
--- a/MechanizedAI-CrossAccount-Role.json
+++ b/MechanizedAI-CrossAccount-Role.json
@@ -84,6 +84,8 @@
                                         "lambda:ListLayerVersions",
                                         "lambda:DeleteLayerVersion",
                                         "lambda:ListFunctions",
+                                        "lambda:TagResource",
+                                        "lambda:UntagResource",
                                         "elasticloadbalancing:*",
                                         "elasticfilesystem:*",
                                         "ssm:*",
@@ -113,7 +115,11 @@
                                         "iam:DeletePolicy",
                                         "iam:DeletePolicyVersion",
                                         "iam:DeleteRolePolicy",
-                                        "iam:DetachRolePolicy"
+                                        "iam:DetachRolePolicy",
+                                        "iam:TagRole",
+                                        "iam:UntagRole",
+                                        "iam:TagPolicy",
+                                        "iam:UntagPolicy"
                                     ],
                                     "Resource": [
                                         "*"


### PR DESCRIPTION
## Summary
- Add `lambda:TagResource` and `lambda:UntagResource` permissions for tagging Lambda functions
- Add `iam:TagRole`, `iam:UntagRole`, `iam:TagPolicy`, and `iam:UntagPolicy` permissions for tagging IAM resources

## Context
These permissions are required to support the Pulumi resource transformation that automatically applies tags to all AWS resources, including the `aws-apn-id` tag for AWS Partner Network tracking.

## Changes
Updated the MechanizedAI-CrossAccount-Role CloudFormation template to include:
- Lambda tagging permissions in the first statement
- IAM tagging permissions in the second statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)